### PR TITLE
tolerate slight differences in colour

### DIFF
--- a/x11_handling.cpp
+++ b/x11_handling.cpp
@@ -34,7 +34,7 @@ const int ASSUMED_XIMAGE_BITS_PER_PIXEL = 32;
 const int ASSUMED_XIMAGE_RED_MASK = 16711680;
 const int ASSUMED_XIMAGE_GREEN_MASK = 65280;
 const int ASSUMED_XIMAGE_BLUE_MASK = 255;
-const int ASSUMED_XIMAGE_PIXEL_PAD = 0;
+// const int ASSUMED_XIMAGE_PIXEL_PAD = 0;
 const int ITEM_SIZE = 60;
 const int BOARD_PIXEL_WIDTH = Board::MAX_COLS * ITEM_SIZE;
 const int BOARD_PIXEL_HEIGHT_ITEMS = 526; // eyeballed, ~10 pixels safety from red haze. should be smaller than Board::MAX_ROWS * ITEM_SIZE;
@@ -315,16 +315,16 @@ void validateAssumptions(Display *display, Window window) {
         error = true;
     }
 
-    uint32_t testPixel;
-    memcpy(&testPixel, xImage->data, sizeof(testPixel));
-    const int pixelPad = testPixel >> 24;
-    if (pixelPad != ASSUMED_XIMAGE_PIXEL_PAD) {
-        std::cerr << "pixelPad: " << pixelPad << ", but was assumed to be: " << ASSUMED_XIMAGE_PIXEL_PAD << '\n';
-        error = true;
-    }
-    if (error) {
-        throw std::runtime_error("bad XImage format");
-    }
+//  uint32_t testPixel;
+//  memcpy(&testPixel, xImage->data, sizeof(testPixel));
+//  const int pixelPad = testPixel >> 24;
+//  if (pixelPad != ASSUMED_XIMAGE_PIXEL_PAD) {
+//      std::cerr << "pixelPad: " << pixelPad << ", but was assumed to be: " << ASSUMED_XIMAGE_PIXEL_PAD << '\n';
+//      error = true;
+//  }
+//  if (error) {
+//      throw std::runtime_error("bad XImage format");
+//  }
 
     for (int y=0; y<30; ++y) {
         for (int x=0; x<30; ++x) {

--- a/x11_handling.cpp
+++ b/x11_handling.cpp
@@ -329,7 +329,7 @@ void validateAssumptions(Display *display, Window window) {
     for (int y=0; y<30; ++y) {
         for (int x=0; x<30; ++x) {
             const unsigned long correctPixel = XGetPixel(xImage, x, y);
-            const int correctRed = correctPixel >> 16;
+            const int correctRed = (correctPixel & ASSUMED_XIMAGE_RED_MASK) >> 16;
             const int correctGreen = (correctPixel & ASSUMED_XIMAGE_GREEN_MASK) >> 8;
             const int correctBlue = (correctPixel & ASSUMED_XIMAGE_BLUE_MASK);
 

--- a/x11_handling.cpp
+++ b/x11_handling.cpp
@@ -166,33 +166,33 @@ int imgcmp(const void *p1, const void *p2, size_t len) {
 uint8_t dataOffsettedToItem(char* data) {
     uint32_t pixel;
     memcpy(&pixel, data, sizeof(pixel));
-    switch (pixel) {
-    case YELLOW_PIXEL:
-        if (memcmp(data, YELLOW_DATA, sizeof(YELLOW_DATA))==0) return Board::YELLOW;
-        break;
-    case GREEN_PIXEL:
-        if (memcmp(data, GREEN_DATA, sizeof(GREEN_DATA))==0) return Board::GREEN;
-        break;
-    case RED_PIXEL:
-        if (memcmp(data, RED_DATA, sizeof(RED_DATA))==0) return Board::RED;
-        break;
-    case PINK_PIXEL:
-        if (memcmp(data, PINK_DATA, sizeof(PINK_DATA))==0) return Board::PINK;
-        break;
-    case BLUE_PIXEL:
-        if (memcmp(data, BLUE_DATA, sizeof(BLUE_DATA))==0) return Board::BLUE;
-        break;
-    case YELLOW_BOMB_PIXEL:
-        return Board::YELLOW_BOMB;
-    case GREEN_BOMB_PIXEL:
-        return Board::GREEN_BOMB;
-    case RED_BOMB_PIXEL:
-        return Board::RED_BOMB;
-    case PINK_BOMB_PIXEL:
-        return Board::PINK_BOMB;
-    case BLUE_BOMB_PIXEL:
-        return Board::BLUE_BOMB;
+
+    if (pixelcmp(pixel,YELLOW_PIXEL)==0) {
+        if (imgcmp(data, YELLOW_DATA, sizeof(YELLOW_DATA))==0) return Board::YELLOW;
     }
+    else if (pixelcmp(pixel,GREEN_PIXEL)==0) {
+        if (imgcmp(data, GREEN_DATA, sizeof(GREEN_DATA))==0) return Board::GREEN;
+    }
+    else if (pixelcmp(pixel,RED_PIXEL)==0) {
+        if (imgcmp(data, RED_DATA, sizeof(RED_DATA))==0) return Board::RED;
+    }
+    else if (pixelcmp(pixel,PINK_PIXEL)==0) {
+        if (imgcmp(data, PINK_DATA, sizeof(PINK_DATA))==0) return Board::PINK;
+    }
+    else if (pixelcmp(pixel,BLUE_PIXEL)==0) {
+        if (imgcmp(data, BLUE_DATA, sizeof(BLUE_DATA))==0) return Board::BLUE;
+    }
+    else if (pixelcmp(pixel,YELLOW_BOMB_PIXEL)==0)
+        return Board::YELLOW_BOMB;
+    else if (pixelcmp(pixel,GREEN_BOMB_PIXEL)==0)
+        return Board::GREEN_BOMB;
+    else if (pixelcmp(pixel,RED_BOMB_PIXEL)==0)
+        return Board::RED_BOMB;
+    else if (pixelcmp(pixel,PINK_BOMB_PIXEL)==0)
+        return Board::PINK_BOMB;
+    else if (pixelcmp(pixel,BLUE_BOMB_PIXEL)==0)
+        return Board::BLUE_BOMB;
+
     return Board::EMPTY;
 }
 
@@ -222,7 +222,7 @@ std::optional<int> findGameYOffset(char* data) {
 std::optional<uint8_t> findPhageColumn(char* data) {
     for (uint8_t col=0; col<Board::MAX_COLS; ++col) {
         const std::size_t offset = pixelCoordToDataOffset(col*ITEM_SIZE + PHAGE_SILVER_DATA_X_OFFSET, PHAGE_SILVER_DATA_Y_OFFSET);
-        if (memcmp(data+offset, PHAGE_SILVER_DATA, sizeof(PHAGE_SILVER_DATA)) == 0) {
+        if (imgcmp(data+offset, PHAGE_SILVER_DATA, sizeof(PHAGE_SILVER_DATA)) == 0) {
             return {col};
         }
     }
@@ -234,7 +234,7 @@ uint8_t findHeld(char* data, const uint8_t phageCol) {
     const std::size_t heldOffset = pixelCoordToDataOffset(phageCol*ITEM_SIZE + PIXEL_X_OFFSET, PHAGE_HELD_Y_OFFSET);
     const uint8_t held = dataOffsettedToItem(data+heldOffset);
     const std::size_t pinkOffset = pixelCoordToDataOffset(phageCol*ITEM_SIZE + PHAGE_PINK_DATA_X_OFFSET, PHAGE_PINK_DATA_Y_OFFSET);
-    const bool foundPink = 0 == memcmp(data+pinkOffset, PHAGE_PINK_DATA, sizeof(PHAGE_PINK_DATA));
+    const bool foundPink = 0 == imgcmp(data+pinkOffset, PHAGE_PINK_DATA, sizeof(PHAGE_PINK_DATA));
     assert(foundPink == (held == Board::EMPTY));
     return held;
 }


### PR DESCRIPTION
Just in case this is of interest (feel free to ignore if not)...

The copy of the game I ran this bot against appeared to have very slightly different colours for the blocks and also for the EXA at the bottom, so the bot failed to find the correct column and also didn't spot half the blocks on the screen.

I've modified all the pixel comparisons to support a fuzzy match by comparing the RGB values of the pixels and matching if they are close enough.  When I ran this with a fuzz of 3 it worked perfectly.

This also fixes the problem reported by Starwort in issue #1 because with this kind of comparison we no longer need to rely on the pad byte being a specific value.  It seems that newer X11 servers use a pad byte of 255 while the code originally assumed a pad byte of 0.